### PR TITLE
[Feat] 자격증 진위 여부 확인 API 구현 (#52)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // WebClient
+    implementation 'io.codef.api:easycodef-java:1.0.6'
+
     // --- JPA & MariaDB ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/backend/src/main/java/com/beyond/specguard/certificate/controller/CertificateController.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/controller/CertificateController.java
@@ -1,15 +1,14 @@
 package com.beyond.specguard.certificate.controller;
 
+import com.beyond.specguard.certificate.model.dto.CertificateVerifyRequestDto;
 import com.beyond.specguard.certificate.model.entity.ResumeCertificate;
 import com.beyond.specguard.certificate.model.service.CertificateVerificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,13 +17,14 @@ public class CertificateController {
 
     private final CertificateVerificationService verificationService;
 
-    @PostMapping("/{certificateId}/verify")
-    public ResponseEntity<String> verify(@PathVariable UUID certificateId) {
+    @PostMapping("/verify")
+    public ResponseEntity<String> verify(
+            @RequestBody CertificateVerifyRequestDto requestDto
+    ) {
         // certificateId 로 Certificate 조회했다고 가정
         ResumeCertificate certificate = ResumeCertificate.builder()
-                        .id(certificateId)
-                        .certificateNumber("20260245205321")
-                        .certificateName("정보처리기사")
+                        .id(requestDto.getResumeId())
+                        .certificateNumber("2025***************")
                         .build();
 
         verificationService.verifyCertificateAsync(certificate);

--- a/backend/src/main/java/com/beyond/specguard/certificate/controller/CertificateController.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/controller/CertificateController.java
@@ -1,0 +1,34 @@
+package com.beyond.specguard.certificate.controller;
+
+import com.beyond.specguard.certificate.model.entity.ResumeCertificate;
+import com.beyond.specguard.certificate.model.service.CertificateVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/certificates")
+public class CertificateController {
+
+    private final CertificateVerificationService verificationService;
+
+    @PostMapping("/{certificateId}/verify")
+    public ResponseEntity<String> verify(@PathVariable UUID certificateId) {
+        // certificateId 로 Certificate 조회했다고 가정
+        ResumeCertificate certificate = ResumeCertificate.builder()
+                        .id(certificateId)
+                        .certificateNumber("20260245205321")
+                        .certificateName("정보처리기사")
+                        .build();
+
+        verificationService.verifyCertificateAsync(certificate);
+
+        return ResponseEntity.ok("Verification started (async)");
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/config/EasyCodefClientInfo.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/config/EasyCodefClientInfo.java
@@ -1,0 +1,18 @@
+package com.beyond.specguard.certificate.model.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class EasyCodefClientInfo {
+    @Value("${codef.public_key}")
+    public String PUBLIC_KEY;
+
+    @Value("${codef.demo_client_id}")
+    public String DEMO_CLIENT_ID;
+
+    @Value("${codef.demo_client_secret}")
+    public String DEMO_CLIENT_SECRET;
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CertificateVerifyRequestDto.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CertificateVerifyRequestDto.java
@@ -1,0 +1,14 @@
+package com.beyond.specguard.certificate.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CertificateVerifyRequestDto {
+    private UUID resumeId;
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationRequest.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationRequest.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @Data
 @Builder
 public class CodefVerificationRequest {
-    private String organization; // "0001"
+    private String organization = "0001"; //
     private String userName;
     private String docNo;
 }

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationRequest.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationRequest.java
@@ -1,0 +1,13 @@
+package com.beyond.specguard.certificate.model.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class CodefVerificationRequest {
+    private String organization; // "0001"
+    private String userName;
+    private String docNo;
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationResponse.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationResponse.java
@@ -3,10 +3,39 @@ package com.beyond.specguard.certificate.model.dto;
 import lombok.Data;
 
 import java.util.List;
-import java.util.Map;
 
 @Data
 public class CodefVerificationResponse {
-    private Map<String, Object> result;
-    private List<Map<String, Object>> lists;
+    private Result result;
+    private DataDto data;
+
+    @Data
+    public static class Result {
+        private String code;
+        private String extraMessage;
+        private String message;
+        private String transactionId;
+    }
+
+    @Data
+    public static class DataDto {
+        private String resIssueYN;
+        private String resResultDesc;
+        private String resDocNo;
+        private String resPublishNo;
+        private String resType;
+        private String resUserNm;
+        private String resExaminationNo;
+        private String resAcquisitionDate;
+        private String resInquiryDate;
+        private String commBirthDate;
+        private String resDocType;
+        private List<ResItem> resItemList;
+    }
+
+    @Data
+    public static class ResItem {
+        private String resItemName;
+        private String resPassDate;
+    }
 }

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationResponse.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/dto/CodefVerificationResponse.java
@@ -1,0 +1,12 @@
+package com.beyond.specguard.certificate.model.dto;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class CodefVerificationResponse {
+    private Map<String, Object> result;
+    private List<Map<String, Object>> lists;
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/dto/ResumeCertificateDto.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/dto/ResumeCertificateDto.java
@@ -1,0 +1,21 @@
+package com.beyond.specguard.certificate.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResumeCertificateDto {
+    private String id;
+    private String certificateName;
+    private String certificateNumber;
+    private String issuer;
+    private LocalDate issuedDate;
+    private String certUrl;
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/entity/CertificateVerification.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/entity/CertificateVerification.java
@@ -1,0 +1,65 @@
+package com.beyond.specguard.certificate.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "certificate_verification")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CertificateVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id; // UUID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "certificate_id", nullable = false)
+    private ResumeCertificate resumeCertificate;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private String verificationSource; // "CODEF"
+    private String errorMessage;
+
+    private LocalDateTime verifiedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        if (status == null) status = Status.PENDING;
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public enum Status {
+        PENDING, SUCCESS, FAILED
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/entity/ResumeCertificate.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/entity/ResumeCertificate.java
@@ -1,0 +1,70 @@
+package com.beyond.specguard.certificate.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Entity
+@Table(name = "resume_certificate")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumeCertificate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id; // UUID
+
+
+    // TODO 차후 resume과 연결
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "resume_id", nullable = false)
+    @Column(name = "resume_id", nullable = false)
+    private UUID resume;
+
+    @Column(name = "certificate_name", nullable = false)
+    private String certificateName;
+
+    @Column(name = "certificate_number", nullable = false)
+    private String certificateNumber;
+
+    @Column(name = "issuer", nullable = false)
+    private String issuer;
+
+    @Column(name = "issued_date", nullable = false)
+    private LocalDate issuedDate;
+
+    @Column(name = "cert_url")
+    private String certUrl;
+
+    @Column(name = "created_at", updatable = false, insertable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/repository/CertificateVerificationRepository.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/repository/CertificateVerificationRepository.java
@@ -1,0 +1,7 @@
+package com.beyond.specguard.certificate.model.repository;
+
+import com.beyond.specguard.certificate.model.entity.CertificateVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CertificateVerificationRepository extends JpaRepository<CertificateVerification, String> {
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/service/CertificateVerificationService.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/service/CertificateVerificationService.java
@@ -1,0 +1,65 @@
+package com.beyond.specguard.certificate.model.service;
+
+import com.beyond.specguard.certificate.model.dto.CodefVerificationRequest;
+import com.beyond.specguard.certificate.model.dto.CodefVerificationResponse;
+import com.beyond.specguard.certificate.model.entity.CertificateVerification;
+import com.beyond.specguard.certificate.model.entity.ResumeCertificate;
+import com.beyond.specguard.certificate.model.repository.CertificateVerificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CertificateVerificationService {
+
+    private final CodefClient codefClient;
+    private final CertificateVerificationRepository verificationRepository;
+
+    @Async
+    @Transactional
+    public void verifyCertificateAsync(ResumeCertificate certificate) {
+        CertificateVerification verification = CertificateVerification.builder()
+                        .resumeCertificate(certificate)
+                        .build();
+
+        verificationRepository.save(verification);
+
+        try {
+            // 요청 DTO 구성
+            CodefVerificationRequest request = CodefVerificationRequest.builder()
+                    .organization("0001")
+                    // .userName(certificate.getUserName())
+                    .userName("서현원")
+                    .docNo(certificate.getCertificateNumber())
+                    .build();
+
+            // API 호출
+            CodefVerificationResponse response = codefClient.verifyCertificate(request);
+
+            log.debug(response.toString());
+
+            verification.setVerifiedAt(LocalDateTime.now());
+
+            // 성공 여부 판별
+            String resIssueYN = (String) response.getLists().get(0).get("resIssueYN");
+            if ("1".equals(resIssueYN)) {
+                verification.setStatus(CertificateVerification.Status.SUCCESS);
+            } else {
+                verification.setStatus(CertificateVerification.Status.FAILED);
+                verification.setErrorMessage((String) response.getLists().get(0).get("resResultDesc"));
+            }
+
+        } catch (Exception e) {
+            verification.setStatus(CertificateVerification.Status.FAILED);
+            verification.setErrorMessage(e.getMessage());
+        }
+
+        verificationRepository.save(verification);
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/service/CertificateVerificationService.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/service/CertificateVerificationService.java
@@ -25,6 +25,7 @@ public class CertificateVerificationService {
     @Transactional
     public void verifyCertificateAsync(ResumeCertificate certificate) {
         CertificateVerification verification = CertificateVerification.builder()
+                        .verificationSource("CODEF")
                         .resumeCertificate(certificate)
                         .build();
 
@@ -34,8 +35,7 @@ public class CertificateVerificationService {
             // 요청 DTO 구성
             CodefVerificationRequest request = CodefVerificationRequest.builder()
                     .organization("0001")
-                    // .userName(certificate.getUserName())
-                    .userName("서현원")
+                    .userName("***")
                     .docNo(certificate.getCertificateNumber())
                     .build();
 
@@ -47,12 +47,12 @@ public class CertificateVerificationService {
             verification.setVerifiedAt(LocalDateTime.now());
 
             // 성공 여부 판별
-            String resIssueYN = (String) response.getLists().get(0).get("resIssueYN");
+            String resIssueYN = response.getData().getResIssueYN();
             if ("1".equals(resIssueYN)) {
                 verification.setStatus(CertificateVerification.Status.SUCCESS);
             } else {
                 verification.setStatus(CertificateVerification.Status.FAILED);
-                verification.setErrorMessage((String) response.getLists().get(0).get("resResultDesc"));
+                verification.setErrorMessage(response.getData().getResResultDesc());
             }
 
         } catch (Exception e) {

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/service/CodefClient.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/service/CodefClient.java
@@ -1,0 +1,62 @@
+package com.beyond.specguard.certificate.model.service;
+
+import com.beyond.specguard.certificate.model.config.EasyCodefClientInfo;
+import com.beyond.specguard.certificate.model.dto.CodefVerificationRequest;
+import com.beyond.specguard.certificate.model.dto.CodefVerificationResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codef.api.EasyCodef;
+import io.codef.api.EasyCodefServiceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CodefClient {
+
+    private final EasyCodefClientInfo easyCodefClientInfo;
+    // private final WebClient webClient = WebClient.builder()
+    //         .baseUrl("https://development.codef.io") // 실제 endpoint로 교체 필요
+    //         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+    //         .build();
+
+    public CodefVerificationResponse verifyCertificate(CodefVerificationRequest request) throws IOException, InterruptedException {
+        // (Connected ID 미사용)
+
+        /** #1.쉬운 코드에프 객체 생성 및 클라이언트 정보 설정 */
+        EasyCodef codef = new EasyCodef();
+        codef.setClientInfoForDemo(easyCodefClientInfo.DEMO_CLIENT_ID, easyCodefClientInfo.DEMO_CLIENT_SECRET);
+        codef.setPublicKey(easyCodefClientInfo.PUBLIC_KEY);
+
+        log.debug(easyCodefClientInfo.DEMO_CLIENT_ID);
+        log.debug(easyCodefClientInfo.DEMO_CLIENT_SECRET);
+
+        /** #5.요청 파라미터 설정 - 각 상품별 파라미터를 설정(https://developer.codef.io/products) */
+        HashMap<String, Object> parameterMap = new HashMap<String, Object>();
+        parameterMap.put("organization", "0001"); // 기관코드 설정
+        // parameterMap.put("username", request.getUserName());
+        parameterMap.put("userName", "서현원");
+        parameterMap.put("docNo", "12345678901A");
+
+
+        log.debug(request.toString());
+        log.debug(parameterMap.toString());
+
+        /** #6.코드에프 정보 조회 요청 - 서비스타입(API:정식, DEMO:데모, SANDBOX:샌드박스) */
+        String productUrl = "/v1/kr/etc/hr/qnet-certificate/status";
+        String result = codef.requestProduct(productUrl, EasyCodefServiceType.DEMO, parameterMap);
+
+        /**	#7.코드에프 정보 결과 확인	*/
+        System.out.println(result);
+
+        CodefVerificationResponse responseMap = new ObjectMapper().readValue(result, CodefVerificationResponse.class);
+
+        return responseMap ;
+
+        // assertEquals("코드에프 상품 요청 결과 실패(반환된 코드와 메시지 확인 필요)", "CF-00000", (String)resultMap.get("code"));
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/certificate/model/service/CodefClient.java
+++ b/backend/src/main/java/com/beyond/specguard/certificate/model/service/CodefClient.java
@@ -19,14 +19,9 @@ import java.util.HashMap;
 public class CodefClient {
 
     private final EasyCodefClientInfo easyCodefClientInfo;
-    // private final WebClient webClient = WebClient.builder()
-    //         .baseUrl("https://development.codef.io") // 실제 endpoint로 교체 필요
-    //         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-    //         .build();
 
     public CodefVerificationResponse verifyCertificate(CodefVerificationRequest request) throws IOException, InterruptedException {
         // (Connected ID 미사용)
-
         /** #1.쉬운 코드에프 객체 생성 및 클라이언트 정보 설정 */
         EasyCodef codef = new EasyCodef();
         codef.setClientInfoForDemo(easyCodefClientInfo.DEMO_CLIENT_ID, easyCodefClientInfo.DEMO_CLIENT_SECRET);
@@ -37,10 +32,9 @@ public class CodefClient {
 
         /** #5.요청 파라미터 설정 - 각 상품별 파라미터를 설정(https://developer.codef.io/products) */
         HashMap<String, Object> parameterMap = new HashMap<String, Object>();
-        parameterMap.put("organization", "0001"); // 기관코드 설정
-        // parameterMap.put("username", request.getUserName());
-        parameterMap.put("userName", "서현원");
-        parameterMap.put("docNo", "12345678901A");
+        parameterMap.put("organization", request.getOrganization()); // 기관코드 설정
+        parameterMap.put("userName", request.getUserName());
+        parameterMap.put("docNo", request.getDocNo());
 
 
         log.debug(request.toString());
@@ -56,7 +50,5 @@ public class CodefClient {
         CodefVerificationResponse responseMap = new ObjectMapper().readValue(result, CodefVerificationResponse.class);
 
         return responseMap ;
-
-        // assertEquals("코드에프 상품 요청 결과 실패(반환된 코드와 메시지 확인 필요)", "CF-00000", (String)resultMap.get("code"));
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/common/config/AsyncConfig.java
+++ b/backend/src/main/java/com/beyond/specguard/common/config/AsyncConfig.java
@@ -1,0 +1,17 @@
+package com.beyond.specguard.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        return Executors.newFixedThreadPool(5);
+    }
+}


### PR DESCRIPTION

## 💡 작업 개요
- 외부 인증 기관(CODEF)과 연동하여 지원자의 자격증 진위 여부를 검증하는 API 구현

</br>

## 🔨 작업 내용
- `CertificateResponseDto` 생성 (외부 API 응답 매핑)
- 자격증 검증 API 호출 Service (`CertificateVerificationService`) 구현
- API 응답값 파싱 후 검증 결과를 DB(`resume_certificate_verification` 테이블) 저장
- 예외 처리 (API 응답 오류, 인증 실패 등) 로직 추가
- Controller 단에서 기업/관리자가 자격증 진위 여부를 조회할 수 있도록 엔드포인트 제공

</br>

## 🎯 관련 이슈
closes #52 
- #52

</br>

## 📚 참고 자료 (선택)
- [Codef 확인증 진위여부 API 문서](https://developer.codef.io/products/etc/each/hr/certificate/status) 
- [codef java simple구현](https://github.com/codef-io/easycodef-java)
