### PR TITLE
[Feat] 가중치 프로필 CRUD API 구현 (#62)

### DIFF
--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/controller/EvaluationProfileController.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/controller/EvaluationProfileController.java
@@ -1,41 +1,97 @@
 package com.beyond.specguard.evaluationprofile.controller;
 
-import com.beyond.specguard.auth.model.entity.ClientCompany;
+import com.beyond.specguard.auth.model.entity.ClientUser;
 import com.beyond.specguard.auth.model.service.CustomUserDetails;
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.GetEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.SearchEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
+import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileListResponseDto;
 import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileResponseDto;
-import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.service.EvaluationProfileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
+@Slf4j
 @RestController
-@RequestMapping("/api/v1/company")
+@RequestMapping("/api/v1/evaluationProfiles")
 @RequiredArgsConstructor
 public class EvaluationProfileController {
 
     private final EvaluationProfileService evaluationProfileService;
 
-    @PostMapping("/evaluationProfile")
+    @PostMapping("/")
     public ResponseEntity<EvaluationProfileResponseDto> createProfile(
             @Valid @RequestBody EvaluationProfileRequestDto request,
             Authentication authentication
     ) {
-        // company 추출
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-        ClientCompany company = customUserDetails.getUser().getCompany();
+        ClientUser user =  getUserDetails(authentication).getUser();
+        EvaluationProfileResponseDto responseDto = evaluationProfileService.createProfile(new CreateEvaluationProfileCommand(user, request));
 
-        EvaluationProfile evaluationProfile = evaluationProfileService.createProfile(new CreateEvaluationProfileCommand(company, request));
-
-        return ResponseEntity.ok(EvaluationProfileResponseDto.fromEntity(evaluationProfile));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(responseDto);
     }
 
 
+    private CustomUserDetails getUserDetails(Authentication authentication) {
+        // company 추출
+        return (CustomUserDetails) authentication.getPrincipal();
+    }
+
+    @GetMapping("/{profileId}")
+    public ResponseEntity<EvaluationProfileResponseDto> getProfile(
+            @PathVariable UUID profileId,
+            Authentication authentication
+    ) {
+        ClientUser user = getUserDetails(authentication).getUser();
+
+        EvaluationProfileResponseDto responseDto = evaluationProfileService.getProfile(new GetEvaluationProfileCommand(profileId, user));
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<EvaluationProfileListResponseDto> getProfiles(
+            @RequestParam(required = false) Boolean isActive,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Authentication authentication
+    ) {
+        ClientUser user = getUserDetails(authentication).getUser();
+
+        EvaluationProfileListResponseDto profilesResponseDto = evaluationProfileService.getProfiles(
+                new SearchEvaluationProfileCommand(user, isActive, pageable)
+        );
+
+        return ResponseEntity.ok(profilesResponseDto);
+    }
+
+    @DeleteMapping("/{profileId}")
+    public ResponseEntity<Void> deleteProfile(
+            @PathVariable UUID profileId,
+            Authentication authentication
+    ) {
+        ClientUser user = getUserDetails(authentication).getUser();
+
+        evaluationProfileService.deleteProfile(user, profileId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/controller/EvaluationProfileController.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/controller/EvaluationProfileController.java
@@ -1,0 +1,41 @@
+package com.beyond.specguard.evaluationprofile.controller;
+
+import com.beyond.specguard.auth.model.entity.ClientCompany;
+import com.beyond.specguard.auth.model.service.CustomUserDetails;
+import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
+import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileResponseDto;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import com.beyond.specguard.evaluationprofile.model.service.EvaluationProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/company")
+@RequiredArgsConstructor
+public class EvaluationProfileController {
+
+    private final EvaluationProfileService evaluationProfileService;
+
+    @PostMapping("/evaluationProfile")
+    public ResponseEntity<EvaluationProfileResponseDto> createProfile(
+            @Valid @RequestBody EvaluationProfileRequestDto request,
+            Authentication authentication
+    ) {
+        // company 추출
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        ClientCompany company = customUserDetails.getUser().getCompany();
+
+        EvaluationProfile evaluationProfile = evaluationProfileService.createProfile(new CreateEvaluationProfileCommand(company, request));
+
+        return ResponseEntity.ok(EvaluationProfileResponseDto.fromEntity(evaluationProfile));
+    }
+
+
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/controller/EvaluationProfileController.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/controller/EvaluationProfileController.java
@@ -5,13 +5,20 @@ import com.beyond.specguard.auth.model.service.CustomUserDetails;
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.command.GetEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.command.SearchEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.UpdateEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
 import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileListResponseDto;
 import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileResponseDto;
 import com.beyond.specguard.evaluationprofile.model.service.EvaluationProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -22,6 +29,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,65 +41,113 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/evaluationProfiles")
 @RequiredArgsConstructor
+@Tag(name = "가중치 프로필 관련 API", description = "가중치 프로필과 관련된 API를 정의합니다.")
 public class EvaluationProfileController {
 
     private final EvaluationProfileService evaluationProfileService;
 
+    // Authentication 에서 UserDetails 추출 메소드
+    // TODO: 한 클래스에 둬서 메소드 불러와 사용하기 예) AuthUtil
+    private CustomUserDetails getUserDetails(Authentication authentication) {
+        return (CustomUserDetails) authentication.getPrincipal();
+    }
+
+    @Operation(summary = "평가 프로필 생성", description = "기업 유저 또는 어드민이 새로운 평가 프로필을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "프로필 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/")
     public ResponseEntity<EvaluationProfileResponseDto> createProfile(
             @Valid @RequestBody EvaluationProfileRequestDto request,
             Authentication authentication
     ) {
-        ClientUser user =  getUserDetails(authentication).getUser();
-        EvaluationProfileResponseDto responseDto = evaluationProfileService.createProfile(new CreateEvaluationProfileCommand(user, request));
+        ClientUser user = getUserDetails(authentication).getUser();
+        EvaluationProfileResponseDto responseDto =
+                evaluationProfileService.createProfile(new CreateEvaluationProfileCommand(user, request));
 
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(responseDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
 
-    private CustomUserDetails getUserDetails(Authentication authentication) {
-        // company 추출
-        return (CustomUserDetails) authentication.getPrincipal();
-    }
-
+    @Operation(summary = "평가 프로필 단건 조회", description = "특정 평가 프로필을 조회합니다. 기업 유저 권한 필요.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "프로필을 찾을 수 없음")
+    })
     @GetMapping("/{profileId}")
     public ResponseEntity<EvaluationProfileResponseDto> getProfile(
+            @Parameter(description = "조회할 프로필 ID", required = true)
             @PathVariable UUID profileId,
             Authentication authentication
     ) {
         ClientUser user = getUserDetails(authentication).getUser();
-
-        EvaluationProfileResponseDto responseDto = evaluationProfileService.getProfile(new GetEvaluationProfileCommand(profileId, user));
+        EvaluationProfileResponseDto responseDto =
+                evaluationProfileService.getProfile(new GetEvaluationProfileCommand(profileId, user));
 
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(summary = "평가 프로필 목록 조회", description = "해당 기업의 평가 프로필 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음")
+    })
     @GetMapping("/")
     public ResponseEntity<EvaluationProfileListResponseDto> getProfiles(
-            @RequestParam(required = false) Boolean isActive,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @Parameter(description = "활성화 여부 필터") @RequestParam(required = false) Boolean isActive,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+            @ParameterObject
+            Pageable pageable,
             Authentication authentication
     ) {
         ClientUser user = getUserDetails(authentication).getUser();
-
-        EvaluationProfileListResponseDto profilesResponseDto = evaluationProfileService.getProfiles(
-                new SearchEvaluationProfileCommand(user, isActive, pageable)
-        );
+        EvaluationProfileListResponseDto profilesResponseDto =
+                evaluationProfileService.getProfiles(new SearchEvaluationProfileCommand(user, isActive, pageable));
 
         return ResponseEntity.ok(profilesResponseDto);
     }
 
+    @Operation(summary = "평가 프로필 수정", description = "프로필 이름, 설명 등 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "프로필을 찾을 수 없음")
+    })
+    @PutMapping("/{profileId}")
+    public ResponseEntity<EvaluationProfileResponseDto> updateProfile(
+            @Parameter(description = "수정할 프로필 ID", required = true)
+            @PathVariable UUID profileId,
+            @Valid @RequestBody EvaluationProfileRequestDto request,
+            Authentication authentication
+    ) {
+        ClientUser user = getUserDetails(authentication).getUser();
+        EvaluationProfileResponseDto updatedProfileDto =
+                evaluationProfileService.updateProfile(new UpdateEvaluationProfileCommand(user, profileId, request));
+
+        return ResponseEntity.ok(updatedProfileDto);
+    }
+
+    @Operation(summary = "평가 프로필 삭제", description = "평가 프로필을 삭제합니다. (하위 가중치도 함께 제거됨)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "프로필을 찾을 수 없음")
+    })
     @DeleteMapping("/{profileId}")
     public ResponseEntity<Void> deleteProfile(
+            @Parameter(description = "삭제할 프로필 ID", required = true)
             @PathVariable UUID profileId,
             Authentication authentication
     ) {
         ClientUser user = getUserDetails(authentication).getUser();
-
         evaluationProfileService.deleteProfile(user, profileId);
 
         return ResponseEntity.noContent().build();
     }
+
+
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
@@ -9,7 +9,8 @@ public enum EvaluationProfileErrorCode implements ErrorCode{
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 에러"),
     EVALUATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVALUATION_PROFILE_NOT_FOUND", "해당 EvaluationProfile을 찾을 수 없습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "프로필 관련 접근할 권한이 없습니다."),
-    INVALID_WEIGHT_SUM(HttpStatus.BAD_REQUEST, "INVALID_WEIGHT_SUM", "가중치의 총합은 반드시 1이어야 합니다.");
+    INVALID_WEIGHT_SUM(HttpStatus.BAD_REQUEST, "INVALID_WEIGHT_SUM", "가중치의 총합은 반드시 1이어야 합니다."),
+    INVALID_WEIGHT_TYPE(HttpStatus.BAD_REQUEST,"INVALID_WEIGHT_TYPE" , "잘못된 가중치 타입입니다.");
 
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum EvaluationProfileErrorCode implements ErrorCode{
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 에러"),
     EVALUATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVALUATION_PROFILE_NOT_FOUND", "해당 EvaluationProfile을 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "해당 프로필에 접근할 권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "프로필 관련 접근할 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
@@ -1,0 +1,22 @@
+package com.beyond.specguard.evaluationprofile.exception.errorcode;
+
+import com.beyond.specguard.common.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum EvaluationProfileErrorCode implements ErrorCode{
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 에러"),
+    EVALUATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVALUATION_PROFILE_NOT_FOUND", "해당 EvaluationProfile을 찾을 수 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "해당 프로필에 접근할 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    EvaluationProfileErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/exception/errorcode/EvaluationProfileErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 public enum EvaluationProfileErrorCode implements ErrorCode{
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 에러"),
     EVALUATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVALUATION_PROFILE_NOT_FOUND", "해당 EvaluationProfile을 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "프로필 관련 접근할 권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "프로필 관련 접근할 권한이 없습니다."),
+    INVALID_WEIGHT_SUM(HttpStatus.BAD_REQUEST, "INVALID_WEIGHT_SUM", "가중치의 총합은 반드시 1이어야 합니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/CreateEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/CreateEvaluationProfileCommand.java
@@ -1,0 +1,10 @@
+package com.beyond.specguard.evaluationprofile.model.dto.command;
+
+import com.beyond.specguard.auth.model.entity.ClientCompany;
+import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
+
+public record CreateEvaluationProfileCommand(
+        ClientCompany company,
+        EvaluationProfileRequestDto evaluationProfileRequestDto
+) {
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/CreateEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/CreateEvaluationProfileCommand.java
@@ -1,10 +1,10 @@
 package com.beyond.specguard.evaluationprofile.model.dto.command;
 
-import com.beyond.specguard.auth.model.entity.ClientCompany;
+import com.beyond.specguard.auth.model.entity.ClientUser;
 import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
 
 public record CreateEvaluationProfileCommand(
-        ClientCompany company,
+        ClientUser user,
         EvaluationProfileRequestDto evaluationProfileRequestDto
 ) {
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/CreateEvaluationWeightCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/CreateEvaluationWeightCommand.java
@@ -1,0 +1,11 @@
+package com.beyond.specguard.evaluationprofile.model.dto.command;
+
+import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+
+import java.util.List;
+
+public record CreateEvaluationWeightCommand(
+        EvaluationProfile evaluationProfile,
+        List<EvaluationProfileRequestDto.WeightCreateDto> weights)
+{}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/GetEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/GetEvaluationProfileCommand.java
@@ -1,6 +1,10 @@
 package com.beyond.specguard.evaluationprofile.model.dto.command;
 
+import com.beyond.specguard.auth.model.entity.ClientUser;
+
 import java.util.UUID;
 
-public record GetEvaluationProfileCommand(UUID profileId, com.beyond.specguard.auth.model.entity.ClientUser user) {
+public record GetEvaluationProfileCommand(
+        UUID profileId,
+        ClientUser user) {
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/GetEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/GetEvaluationProfileCommand.java
@@ -1,0 +1,6 @@
+package com.beyond.specguard.evaluationprofile.model.dto.command;
+
+import java.util.UUID;
+
+public record GetEvaluationProfileCommand(UUID profileId, com.beyond.specguard.auth.model.entity.ClientUser user) {
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/SearchEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/SearchEvaluationProfileCommand.java
@@ -1,0 +1,7 @@
+package com.beyond.specguard.evaluationprofile.model.dto.command;
+
+public record SearchEvaluationProfileCommand(
+        com.beyond.specguard.auth.model.entity.ClientUser user,
+        Boolean isActive,
+        org.springframework.data.domain.Pageable pageable) {
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/SearchEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/SearchEvaluationProfileCommand.java
@@ -1,7 +1,10 @@
 package com.beyond.specguard.evaluationprofile.model.dto.command;
 
+import com.beyond.specguard.auth.model.entity.ClientUser;
+import org.springframework.data.domain.Pageable;
+
 public record SearchEvaluationProfileCommand(
-        com.beyond.specguard.auth.model.entity.ClientUser user,
+        ClientUser user,
         Boolean isActive,
-        org.springframework.data.domain.Pageable pageable) {
+        Pageable pageable) {
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/UpdateEvaluationProfileCommand.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/command/UpdateEvaluationProfileCommand.java
@@ -1,0 +1,12 @@
+package com.beyond.specguard.evaluationprofile.model.dto.command;
+
+import com.beyond.specguard.auth.model.entity.ClientUser;
+import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
+
+import java.util.UUID;
+
+public record UpdateEvaluationProfileCommand(
+        ClientUser user,
+        UUID profileId,
+        EvaluationProfileRequestDto request) {
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/request/EvaluationProfileRequestDto.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/request/EvaluationProfileRequestDto.java
@@ -1,0 +1,50 @@
+package com.beyond.specguard.evaluationprofile.model.dto.request;
+
+import com.beyond.specguard.auth.model.entity.ClientCompany;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class EvaluationProfileRequestDto {
+    @NotBlank
+    private String name;
+
+    private String description;
+
+    @NotEmpty
+    private List<WeightCreateDto> weights;
+
+    @Getter
+    @NoArgsConstructor
+    public static class WeightCreateDto {
+        @NotNull
+        private EvaluationWeight.WeightType weightType;
+
+        @NotNull
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private Float weightValue;
+
+        public EvaluationWeight toEntity(EvaluationProfile profile) {
+            return EvaluationWeight.builder()
+                    .profile(profile)
+                    .weightType(weightType)
+                    .weightValue(weightValue)
+                    .build();
+        }
+    }
+
+    public EvaluationProfile toEntity(ClientCompany company) {
+        return EvaluationProfile.builder()
+                .company(company)
+                .name(name)
+                .description(description)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/request/EvaluationProfileRequestDto.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/request/EvaluationProfileRequestDto.java
@@ -3,7 +3,12 @@ package com.beyond.specguard.evaluationprofile.model.dto.request;
 import com.beyond.specguard.auth.model.entity.ClientCompany;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,26 +17,28 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class EvaluationProfileRequestDto {
-    @NotBlank
+    @NotBlank(message = "프로필 이름은 필수 입력값입니다.")
+    @Size(max = 50, message = "프로필 이름은 최대 255자까지 입력 가능합니다.")
     private String name;
+
 
     private String description;
 
-    @NotEmpty
+    @NotEmpty(message = "최소 1개 이상의 가중치가 필요합니다.")
     private List<WeightCreateDto> weights;
 
     @Getter
     @NoArgsConstructor
     public static class WeightCreateDto {
-        @NotNull
+        @NotNull(message = "가중치 타입은 필수입니다.")
         private EvaluationWeight.WeightType weightType;
 
-        @NotNull
-        @DecimalMin("0.0")
-        @DecimalMax("1.0")
+        @NotNull(message = "가중치 값은 필수입니다.")
+        @DecimalMin(value = "0.0", message = "가중치 값은 0.0 이상이어야 합니다.")
+        @DecimalMax(value = "1.0", message = "가중치 값은 1.0 이하여야 합니다.")
         private Float weightValue;
 
-        public EvaluationWeight toEntity(EvaluationProfile profile) {
+        public EvaluationWeight fromEntity(EvaluationProfile profile) {
             return EvaluationWeight.builder()
                     .profile(profile)
                     .weightType(weightType)
@@ -40,7 +47,7 @@ public class EvaluationProfileRequestDto {
         }
     }
 
-    public EvaluationProfile toEntity(ClientCompany company) {
+    public EvaluationProfile fromEntity(ClientCompany company) {
         return EvaluationProfile.builder()
                 .company(company)
                 .name(name)

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileListResponseDto.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileListResponseDto.java
@@ -1,0 +1,21 @@
+package com.beyond.specguard.evaluationprofile.model.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationProfileListResponseDto {
+    private List<EvaluationProfileResponseDto> evaluationProfiles;
+    private Long totalElements;
+    private Integer totalPages;
+    private Integer pageNumber;
+    private Integer pageSize;
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileResponseDto.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileResponseDto.java
@@ -2,7 +2,11 @@ package com.beyond.specguard.evaluationprofile.model.dto.response;
 
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.UUID;
@@ -15,6 +19,7 @@ public class EvaluationProfileResponseDto {
     private UUID id;
     private String name;
     private String description;
+    private Boolean isActive;
     private List<EvaluationWeightResponseDto> weights;
 
 
@@ -39,6 +44,7 @@ public class EvaluationProfileResponseDto {
                 .id(evaluationProfile.getId())
                 .name(evaluationProfile.getName())
                 .description(evaluationProfile.getDescription())
+                .isActive(evaluationProfile.getIsActive())
                 .weights(evaluationProfile.getWeights().stream().map(EvaluationWeightResponseDto::new).toList())
                 .build();
     }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileResponseDto.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileResponseDto.java
@@ -1,0 +1,45 @@
+package com.beyond.specguard.evaluationprofile.model.dto.response;
+
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
+import lombok.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationProfileResponseDto {
+    private UUID id;
+    private String name;
+    private String description;
+    private List<EvaluationWeightResponseDto> weights;
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class EvaluationWeightResponseDto {
+        private UUID id;
+        private EvaluationWeight.WeightType weightType;
+        private Float weightValue;
+
+        public EvaluationWeightResponseDto(EvaluationWeight evaluationWeight) {
+            this.id = evaluationWeight.getId();
+            this.weightType = evaluationWeight.getWeightType();
+            this.weightValue = evaluationWeight.getWeightValue();
+        }
+    }
+
+    public static EvaluationProfileResponseDto fromEntity(EvaluationProfile evaluationProfile) {
+        return EvaluationProfileResponseDto.builder()
+                .id(evaluationProfile.getId())
+                .name(evaluationProfile.getName())
+                .description(evaluationProfile.getDescription())
+                .weights(evaluationProfile.getWeights().stream().map(EvaluationWeightResponseDto::new).toList())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileResponseDto.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/dto/response/EvaluationProfileResponseDto.java
@@ -32,10 +32,12 @@ public class EvaluationProfileResponseDto {
         private EvaluationWeight.WeightType weightType;
         private Float weightValue;
 
-        public EvaluationWeightResponseDto(EvaluationWeight evaluationWeight) {
-            this.id = evaluationWeight.getId();
-            this.weightType = evaluationWeight.getWeightType();
-            this.weightValue = evaluationWeight.getWeightValue();
+        public static EvaluationWeightResponseDto fromEntity(EvaluationWeight evaluationWeight) {
+            return EvaluationWeightResponseDto.builder()
+                    .id(evaluationWeight.getId())
+                    .weightType(evaluationWeight.getWeightType())
+                    .weightValue(evaluationWeight.getWeightValue())
+                    .build();
         }
     }
 
@@ -45,7 +47,7 @@ public class EvaluationProfileResponseDto {
                 .name(evaluationProfile.getName())
                 .description(evaluationProfile.getDescription())
                 .isActive(evaluationProfile.getIsActive())
-                .weights(evaluationProfile.getWeights().stream().map(EvaluationWeightResponseDto::new).toList())
+                .weights(evaluationProfile.getWeights().stream().map(EvaluationWeightResponseDto::fromEntity).toList())
                 .build();
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationProfile.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationProfile.java
@@ -1,8 +1,25 @@
 package com.beyond.specguard.evaluationprofile.model.entity;
 
 import com.beyond.specguard.auth.model.entity.ClientCompany;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -17,6 +34,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@ToString
 public class EvaluationProfile {
 
     @Id
@@ -38,7 +56,8 @@ public class EvaluationProfile {
     private String description;
 
     @Column(name = "is_active", nullable = false)
-    private Boolean isActive;
+    @Builder.Default
+    private Boolean isActive = Boolean.TRUE;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -54,6 +73,7 @@ public class EvaluationProfile {
             orphanRemoval = true,
             fetch = FetchType.LAZY
     )
+    @Builder.Default
     private List<EvaluationWeight> weights = new ArrayList<>();
 
     // 상태 변경용 메서드
@@ -63,5 +83,10 @@ public class EvaluationProfile {
 
     public void deactivate() {
         this.isActive = false;
+    }
+
+    public void addWeight(EvaluationWeight evaluationWeight) {
+        this.weights.add(evaluationWeight);
+        evaluationWeight.setProfile(this);
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationProfile.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationProfile.java
@@ -1,6 +1,7 @@
 package com.beyond.specguard.evaluationprofile.model.entity;
 
 import com.beyond.specguard.auth.model.entity.ClientCompany;
+import com.beyond.specguard.evaluationprofile.model.dto.request.EvaluationProfileRequestDto;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -76,17 +77,17 @@ public class EvaluationProfile {
     @Builder.Default
     private List<EvaluationWeight> weights = new ArrayList<>();
 
-    // 상태 변경용 메서드
-    public void activate() {
-        this.isActive = true;
-    }
-
-    public void deactivate() {
-        this.isActive = false;
-    }
-
     public void addWeight(EvaluationWeight evaluationWeight) {
         this.weights.add(evaluationWeight);
         evaluationWeight.setProfile(this);
+    }
+
+    public void update(EvaluationProfileRequestDto dto) {
+        if (dto.getName() != null) {
+            this.name = dto.getName();
+        }
+        if (dto.getDescription() != null) {
+            this.description = dto.getDescription();
+        }
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationProfile.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationProfile.java
@@ -1,0 +1,67 @@
+package com.beyond.specguard.evaluationprofile.model.entity;
+
+import com.beyond.specguard.auth.model.entity.ClientCompany;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "evaluation_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class EvaluationProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "CHAR(36)")
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "company_id",
+            nullable = false,
+            columnDefinition = "CHAR(36)",
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private ClientCompany company;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @OneToMany(
+            mappedBy = "profile",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private List<EvaluationWeight> weights = new ArrayList<>();
+
+    // 상태 변경용 메서드
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
@@ -1,0 +1,72 @@
+package com.beyond.specguard.evaluationprofile.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "evaluation_weight")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class EvaluationWeight {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "CHAR(36)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "evaluation_profile_id",
+            nullable = false,
+            columnDefinition = "CHAR(36)",
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    private EvaluationProfile profile;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "weight_type", nullable = false)
+    private WeightType weightType;
+
+    @Column(name = "weight_value", nullable = false)
+    private Float weightValue;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // 상태 변경용 메서드
+    public void updateWeightValue(Float weightValue) {
+        this.weightValue = weightValue;
+    }
+
+    protected void setProfile(EvaluationProfile profile) {
+        this.profile = profile;
+    }
+
+    public enum WeightType {
+        GITHUB_REPO_COUNT,
+        GITHUB_COMMIT_FREQUENCY,
+        GITHUB_TOPIC_MATCH,
+        GITHUB_CONSISTENCY,
+        NOTION_PROJECT_COUNT,
+        NOTION_DETAIL_DEPTH,
+        NOTION_KEYWORD_MATCH,
+        VELOG_POST_COUNT,
+        VELOG_RECENT_ACTIVITY,
+        VELOG_KEYWORD_MATCH,
+        CAREER_MATCH,
+        CERTIFICATE_MATCH,
+        KEYWORD_MATCH
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
@@ -1,7 +1,22 @@
 package com.beyond.specguard.evaluationprofile.model.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -66,7 +81,6 @@ public class EvaluationWeight {
         VELOG_RECENT_ACTIVITY,
         VELOG_KEYWORD_MATCH,
         CAREER_MATCH,
-        CERTIFICATE_MATCH,
-        KEYWORD_MATCH
+        CERTIFICATE_MATCH
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
@@ -79,12 +79,10 @@ public class EvaluationWeight {
         GITHUB_TOPIC_MATCH,
         GITHUB_CONSISTENCY,
         NOTION_PROJECT_COUNT,
-        NOTION_DETAIL_DEPTH,
         NOTION_KEYWORD_MATCH,
         VELOG_POST_COUNT,
         VELOG_RECENT_ACTIVITY,
         VELOG_KEYWORD_MATCH,
-        CAREER_MATCH,
         CERTIFICATE_MATCH;
 
         @JsonCreator

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/entity/EvaluationWeight.java
@@ -1,5 +1,8 @@
 package com.beyond.specguard.evaluationprofile.model.entity;
 
+import com.beyond.specguard.common.exception.CustomException;
+import com.beyond.specguard.evaluationprofile.exception.errorcode.EvaluationProfileErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -21,6 +24,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.UUID;
 
 @Entity
@@ -81,6 +85,14 @@ public class EvaluationWeight {
         VELOG_RECENT_ACTIVITY,
         VELOG_KEYWORD_MATCH,
         CAREER_MATCH,
-        CERTIFICATE_MATCH
+        CERTIFICATE_MATCH;
+
+        @JsonCreator
+        public static WeightType from(String value) {
+            return Arrays.stream(values())
+                    .filter(type -> type.name().equalsIgnoreCase(value))
+                    .findFirst()
+                    .orElseThrow(() -> new CustomException(EvaluationProfileErrorCode.INVALID_WEIGHT_TYPE));
+        }
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/repository/EvaluationProfileRepository.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/repository/EvaluationProfileRepository.java
@@ -1,9 +1,15 @@
 package com.beyond.specguard.evaluationprofile.model.repository;
 
+import com.beyond.specguard.auth.model.entity.ClientCompany;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface EvaluationProfileRepository extends JpaRepository<EvaluationProfile, UUID> {
+    Page<EvaluationProfile> findByCompanyAndIsActive(ClientCompany company, Boolean active, Pageable pageable);
+
+    Page<EvaluationProfile> findByCompany(ClientCompany company, Pageable pageable);
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/repository/EvaluationProfileRepository.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/repository/EvaluationProfileRepository.java
@@ -1,0 +1,9 @@
+package com.beyond.specguard.evaluationprofile.model.repository;
+
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EvaluationProfileRepository extends JpaRepository<EvaluationProfile, UUID> {
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/repository/EvaluationWeightRepository.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/repository/EvaluationWeightRepository.java
@@ -1,9 +1,11 @@
-package com.beyond.specguard.evaluationprofile.model.respository;
+package com.beyond.specguard.evaluationprofile.model.repository;
 
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface EvaluationWeightRepository extends JpaRepository<EvaluationWeight, UUID> {
+    void deleteByProfile(EvaluationProfile profile);
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/respository/EvaluationWeightRepository.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/respository/EvaluationWeightRepository.java
@@ -1,0 +1,9 @@
+package com.beyond.specguard.evaluationprofile.model.respository;
+
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EvaluationWeightRepository extends JpaRepository<EvaluationWeight, UUID> {
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileService.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileService.java
@@ -1,9 +1,21 @@
 package com.beyond.specguard.evaluationprofile.model.service;
 
+import com.beyond.specguard.auth.model.entity.ClientUser;
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
-import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import com.beyond.specguard.evaluationprofile.model.dto.command.GetEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.SearchEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileListResponseDto;
+import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileResponseDto;
+
+import java.util.UUID;
 
 public interface EvaluationProfileService {
 
-    EvaluationProfile createProfile(CreateEvaluationProfileCommand createEvaluationProfileCommand);
+    EvaluationProfileResponseDto createProfile(CreateEvaluationProfileCommand createEvaluationProfileCommand);
+
+    EvaluationProfileResponseDto getProfile(GetEvaluationProfileCommand getEvaluationProfileCommand);
+
+    EvaluationProfileListResponseDto getProfiles(SearchEvaluationProfileCommand searchEvaluationProfileCommand);
+
+    void deleteProfile(ClientUser user, UUID profileId);
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileService.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileService.java
@@ -1,0 +1,9 @@
+package com.beyond.specguard.evaluationprofile.model.service;
+
+import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+
+public interface EvaluationProfileService {
+
+    EvaluationProfile createProfile(CreateEvaluationProfileCommand createEvaluationProfileCommand);
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileService.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileService.java
@@ -4,6 +4,7 @@ import com.beyond.specguard.auth.model.entity.ClientUser;
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.command.GetEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.command.SearchEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.UpdateEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileListResponseDto;
 import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileResponseDto;
 
@@ -18,4 +19,6 @@ public interface EvaluationProfileService {
     EvaluationProfileListResponseDto getProfiles(SearchEvaluationProfileCommand searchEvaluationProfileCommand);
 
     void deleteProfile(ClientUser user, UUID profileId);
+
+    EvaluationProfileResponseDto updateProfile(UpdateEvaluationProfileCommand updateEvaluationProfileCommand);
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileServiceImpl.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileServiceImpl.java
@@ -1,14 +1,26 @@
 package com.beyond.specguard.evaluationprofile.model.service;
 
+import com.beyond.specguard.auth.model.entity.ClientUser;
+import com.beyond.specguard.common.exception.CustomException;
+import com.beyond.specguard.common.exception.errorcode.CommonErrorCode;
+import com.beyond.specguard.evaluationprofile.exception.errorcode.EvaluationProfileErrorCode;
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationWeightCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.GetEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.SearchEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileListResponseDto;
+import com.beyond.specguard.evaluationprofile.model.dto.response.EvaluationProfileResponseDto;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
 import com.beyond.specguard.evaluationprofile.model.repository.EvaluationProfileRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,15 +28,90 @@ public class EvaluationProfileServiceImpl implements EvaluationProfileService {
 
     private final EvaluationProfileRepository evaluationProfileRepository;
     private final EvaluationWeightService evaluationWeightService;
+
     @Override
-    public EvaluationProfile createProfile(CreateEvaluationProfileCommand command) {
+    @Transactional
+    public EvaluationProfileResponseDto createProfile(CreateEvaluationProfileCommand command) {
+        // 권한 OWNER, MANAGER 체크
+        if (!hasWriteRole(command.user().getRole())) {
+            throw new CustomException(CommonErrorCode.ACCESS_DENIED);
+        }
+
         // EvaluationProfile 생성
-        EvaluationProfile result = evaluationProfileRepository.save(command.evaluationProfileRequestDto().toEntity(command.company()));
+        EvaluationProfile profile = evaluationProfileRepository.save(command.evaluationProfileRequestDto().toEntity(command.user().getCompany()));
 
         // EvaluationWeight 들 생성
         List<EvaluationWeight> weights = evaluationWeightService.createWeights(
-                new CreateEvaluationWeightCommand(result, command.evaluationProfileRequestDto().getWeights()));
+                new CreateEvaluationWeightCommand(profile, command.evaluationProfileRequestDto().getWeights()));
 
-        return result;
+
+        weights.forEach(profile::addWeight);
+
+        return EvaluationProfileResponseDto.fromEntity(profile);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public EvaluationProfileResponseDto getProfile(GetEvaluationProfileCommand command) {
+
+        // 1. EvaluationProfile 조회 (ID 기준)
+        EvaluationProfile profile = evaluationProfileRepository.findById(command.profileId())
+                .orElseThrow(() -> new CustomException(EvaluationProfileErrorCode.EVALUATION_PROFILE_NOT_FOUND));
+
+        // 2. 회사 소속 확인
+        if (!profile.getCompany().getId().equals(command.user().getCompany().getId())) {
+            throw new CustomException(EvaluationProfileErrorCode.ACCESS_DENIED);
+        }
+
+        return EvaluationProfileResponseDto.fromEntity(profile);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public EvaluationProfileListResponseDto getProfiles(SearchEvaluationProfileCommand command) {
+        // 조회
+        Page<EvaluationProfileResponseDto> profilePage = ((command.isActive() != null) ?
+                evaluationProfileRepository.findByCompanyAndIsActive(command.user().getCompany(), command.isActive(), command.pageable()) :
+                evaluationProfileRepository.findByCompany(command.user().getCompany(), command.pageable()))
+                .map(EvaluationProfileResponseDto::fromEntity);
+
+        long totalElements = evaluationProfileRepository.count();
+
+        // DTO 변환
+        return EvaluationProfileListResponseDto.builder()
+                .evaluationProfiles(profilePage.getContent())
+                .totalElements(totalElements)
+                .totalPages(profilePage.getTotalPages())
+                .pageNumber(profilePage.getNumber())
+                .pageSize(profilePage.getSize())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void deleteProfile(ClientUser user, UUID profileId) {
+        // 1. 조회
+        EvaluationProfile profile = evaluationProfileRepository.findById(profileId)
+                .orElseThrow(() -> new CustomException(EvaluationProfileErrorCode.EVALUATION_PROFILE_NOT_FOUND));
+
+        // 2. 회사 일치 체크
+        if (!profile.getCompany().getId().equals(user.getCompany().getId())) {
+            throw new CustomException(CommonErrorCode.ACCESS_DENIED);
+        }
+
+        // 3. 권한 체크
+        if (!user.getRole().equals(ClientUser.Role.OWNER)) {
+            throw new CustomException(CommonErrorCode.ACCESS_DENIED);
+        }
+
+        // 4. 삭제 (하위 항목들도 삭제 필요)
+        evaluationProfileRepository.delete(profile);
+        evaluationWeightService.delete(profile);
+
+
+    }
+
+    private boolean hasWriteRole(ClientUser.Role role) {
+        return EnumSet.of(ClientUser.Role.OWNER, ClientUser.Role.MANAGER).contains(role);
     }
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileServiceImpl.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileServiceImpl.java
@@ -50,7 +50,7 @@ public class EvaluationProfileServiceImpl implements EvaluationProfileService {
         validateWriteRole(command.user().getRole());
 
         // EvaluationProfile 생성
-        EvaluationProfile profile = evaluationProfileRepository.save(command.evaluationProfileRequestDto().toEntity(command.user().getCompany()));
+        EvaluationProfile profile = evaluationProfileRepository.save(command.evaluationProfileRequestDto().fromEntity(command.user().getCompany()));
 
         // EvaluationWeight 들 생성
         List<EvaluationWeight> weights = evaluationWeightService.createWeights(

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileServiceImpl.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationProfileServiceImpl.java
@@ -1,0 +1,30 @@
+package com.beyond.specguard.evaluationprofile.model.service;
+
+import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationProfileCommand;
+import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationWeightCommand;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
+import com.beyond.specguard.evaluationprofile.model.repository.EvaluationProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationProfileServiceImpl implements EvaluationProfileService {
+
+    private final EvaluationProfileRepository evaluationProfileRepository;
+    private final EvaluationWeightService evaluationWeightService;
+    @Override
+    public EvaluationProfile createProfile(CreateEvaluationProfileCommand command) {
+        // EvaluationProfile 생성
+        EvaluationProfile result = evaluationProfileRepository.save(command.evaluationProfileRequestDto().toEntity(command.company()));
+
+        // EvaluationWeight 들 생성
+        List<EvaluationWeight> weights = evaluationWeightService.createWeights(
+                new CreateEvaluationWeightCommand(result, command.evaluationProfileRequestDto().getWeights()));
+
+        return result;
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightService.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightService.java
@@ -1,0 +1,10 @@
+package com.beyond.specguard.evaluationprofile.model.service;
+
+import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationWeightCommand;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
+
+import java.util.List;
+
+public interface EvaluationWeightService {
+    List<EvaluationWeight> createWeights(CreateEvaluationWeightCommand createEvaluationWeightCommand);
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightService.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightService.java
@@ -1,10 +1,13 @@
 package com.beyond.specguard.evaluationprofile.model.service;
 
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationWeightCommand;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
 
 import java.util.List;
 
 public interface EvaluationWeightService {
     List<EvaluationWeight> createWeights(CreateEvaluationWeightCommand createEvaluationWeightCommand);
+
+    void delete(EvaluationProfile profile);
 }

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightServiceImpl.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightServiceImpl.java
@@ -22,7 +22,7 @@ public class EvaluationWeightServiceImpl implements EvaluationWeightService {
         return evaluationWeightRepository.saveAll(
                 command.weights()
                         .stream()
-                        .map(w -> w.toEntity(command.evaluationProfile())).toList()
+                        .map(w -> w.fromEntity(command.evaluationProfile())).toList()
         );
     }
 

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightServiceImpl.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightServiceImpl.java
@@ -1,0 +1,25 @@
+package com.beyond.specguard.evaluationprofile.model.service;
+
+import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationWeightCommand;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
+import com.beyond.specguard.evaluationprofile.model.respository.EvaluationWeightRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationWeightServiceImpl implements EvaluationWeightService {
+
+    private final EvaluationWeightRepository evaluationWeightRepository;
+
+    @Override
+    public List<EvaluationWeight> createWeights(CreateEvaluationWeightCommand command) {
+        return evaluationWeightRepository.saveAll(
+                command.weights()
+                        .stream()
+                        .map(w -> w.toEntity(command.evaluationProfile())).toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightServiceImpl.java
+++ b/backend/src/main/java/com/beyond/specguard/evaluationprofile/model/service/EvaluationWeightServiceImpl.java
@@ -1,10 +1,12 @@
 package com.beyond.specguard.evaluationprofile.model.service;
 
 import com.beyond.specguard.evaluationprofile.model.dto.command.CreateEvaluationWeightCommand;
+import com.beyond.specguard.evaluationprofile.model.entity.EvaluationProfile;
 import com.beyond.specguard.evaluationprofile.model.entity.EvaluationWeight;
-import com.beyond.specguard.evaluationprofile.model.respository.EvaluationWeightRepository;
+import com.beyond.specguard.evaluationprofile.model.repository.EvaluationWeightRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,11 +17,18 @@ public class EvaluationWeightServiceImpl implements EvaluationWeightService {
     private final EvaluationWeightRepository evaluationWeightRepository;
 
     @Override
+    @Transactional
     public List<EvaluationWeight> createWeights(CreateEvaluationWeightCommand command) {
         return evaluationWeightRepository.saveAll(
                 command.weights()
                         .stream()
                         .map(w -> w.toEntity(command.evaluationProfile())).toList()
         );
+    }
+
+    @Override
+    @Transactional
+    public void delete(EvaluationProfile profile) {
+        evaluationWeightRepository.deleteByProfile(profile);
     }
 }


### PR DESCRIPTION
## 💡 작업 개요
<!-- 이번 PR에서 어떤 기능/버그를 다뤘는지 간단 요약 -->
- 기업별 정합성 평가용 가중치 프로필(EvaluationProfile) 생성, 조회, 수정, 삭제 기능 구현
- 각 프로필에 포함되는 EvaluationWeight 항목까지 함께 관리 가능하도록 구현

</br>

## 🔨 작업 내용
<!-- 어떤 변경 사항이 있었는지 구체적으로 설명 -->
- EvaluationProfile 및 EvaluationWeight JPA 엔티티 생성/리팩토링
- 프로필 생성, 조회, 업데이트, 삭제 API 구현 및 Controller, Service, Repository 작성
- 권한 기반 접근 제어 적용 (기업 사용자 권한: OWNER, MANAGER, VIEWER)
- Swagger 어노테이션 추가로 API 문서화
- 평가 프로필과 가중치 연관관계 매핑 및 cascade 설정 적용
- Validation, 예외 처리, DTO 변환 로직 추가

</br>

## 🎯 관련 이슈
<!-- 연결된 이슈가 있다면 아래에 작성 -->
- closes #62

</br>

## 📚 참고 자료 (선택)
<!-- 참고한 외부 문서, 링크가 있다면 작성 -->
- JPA 양방향 연관관계 & Cascade 설정 문서
- Spring Security 권한 기반 접근 제어 관련 자료
- Swagger OpenAPI 문서화 가이드
