### PR TITLE
Feature/93 본인인증 상태 테이블 추가

### DIFF
--- a/backend/src/main/java/com/beyond/specguard/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/beyond/specguard/common/config/SecurityConfig.java
@@ -73,7 +73,10 @@ public class SecurityConfig {
             "/api/v1/auth",
 
             //resume
-            "/api/v1/resumes/**"
+            "/api/v1/resumes/**",
+
+            // verification
+            "/api/v1/verify/**"
     };
 
     private final static String[] ADMIN_AUTH_WHITE_LIST = {

--- a/backend/src/main/java/com/beyond/specguard/verification/controller/EmailVerificationController.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/controller/EmailVerificationController.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/verify/email")
+@RequestMapping("/api/v1/verify")
 @RequiredArgsConstructor
 @Validated
 @Tag(name = "Email Verification", description = "지원자/기업 이메일 인증 API")

--- a/backend/src/main/java/com/beyond/specguard/verification/model/dto/VerifyDto.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/dto/VerifyDto.java
@@ -1,20 +1,24 @@
 package com.beyond.specguard.verification.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public class VerifyDto {
+public final class VerifyDto {
 
     public record EmailRequest(
+            @Schema(example = "specguard@specguard.com")
             @NotBlank
             @Pattern(regexp = "(?i)^[a-z0-9._%+\\-]+@[a-z0-9.-]+\\.[a-z]{2,63}$",
                     message = "유효한 이메일 형식이 아닙니다.")
             String email) {}
 
     public record EmailConfirm(
+            @Schema(example = "specguard@specguard.com")
             @NotBlank(message = "email address required")
             String email,
 
+            @Schema(example = "123456")
             @NotBlank(message = "token required")
             @Pattern(regexp = "^[0-9]{6}$", message = "token must be 6 digits")
             String code) {}

--- a/backend/src/main/java/com/beyond/specguard/verification/model/entity/ApplicantEmailVerification.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/entity/ApplicantEmailVerification.java
@@ -1,0 +1,13 @@
+package com.beyond.specguard.verification.model.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "applicant_email_verify_status",
+        indexes = {
+                @Index(name = "idx_applicant_status", columnList = "status"),
+                @Index(name = "idx_applicant_verified_at", columnList = "verifiedAt")
+        })
+public class ApplicantEmailVerification extends EmailVerificationBase {
+}

--- a/backend/src/main/java/com/beyond/specguard/verification/model/entity/CompanyEmailVerification.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/entity/CompanyEmailVerification.java
@@ -1,0 +1,13 @@
+package com.beyond.specguard.verification.model.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+        name = "company_email_verify_status",
+        indexes = {
+                @Index(name = "idx_company_status", columnList = "status"),
+                @Index(name = "idx_company_verified_at", columnList = "verifiedAt")
+        })
+public class CompanyEmailVerification extends EmailVerificationBase{
+}

--- a/backend/src/main/java/com/beyond/specguard/verification/model/entity/EmailVerificationBase.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/entity/EmailVerificationBase.java
@@ -1,0 +1,49 @@
+package com.beyond.specguard.verification.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+public abstract class EmailVerificationBase {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable=false, unique=true, length=255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable=false, length=16)
+    private EmailVerifyStatus status = EmailVerifyStatus.PENDING;
+
+    @Column(nullable=false)
+    private Integer attempts = 0;
+
+    @Column(nullable=false)
+    private LocalDateTime lastRequestedAt;
+
+    private LocalDateTime verifiedAt;
+
+    @Column(length=45)
+    private String lastIp;
+
+    @Version
+    private Long version;
+
+    @PrePersist
+    void prePersist() {
+        if (lastRequestedAt == null) lastRequestedAt = LocalDateTime.now();
+        if (status == null) status = EmailVerifyStatus.PENDING;
+        if (attempts == null) attempts = 0;
+        if (email != null) email = email.toLowerCase();
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        if (email != null) email = email.toLowerCase();
+    }
+}
+

--- a/backend/src/main/java/com/beyond/specguard/verification/model/entity/EmailVerifyStatus.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/entity/EmailVerifyStatus.java
@@ -1,0 +1,3 @@
+package com.beyond.specguard.verification.model.entity;
+
+public enum EmailVerifyStatus { PENDING, VERIFIED }

--- a/backend/src/main/java/com/beyond/specguard/verification/model/repository/ApplicantEmailVerificationRepo.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/repository/ApplicantEmailVerificationRepo.java
@@ -1,0 +1,11 @@
+package com.beyond.specguard.verification.model.repository;
+
+import com.beyond.specguard.verification.model.entity.ApplicantEmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplicantEmailVerificationRepo
+        extends JpaRepository<ApplicantEmailVerification, Long> {
+    Optional<ApplicantEmailVerification> findByEmail(String email);
+}

--- a/backend/src/main/java/com/beyond/specguard/verification/model/repository/CompanyEmailVerificationRepo.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/repository/CompanyEmailVerificationRepo.java
@@ -1,0 +1,11 @@
+package com.beyond.specguard.verification.model.repository;
+
+import com.beyond.specguard.verification.model.entity.CompanyEmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CompanyEmailVerificationRepo
+        extends JpaRepository<CompanyEmailVerification, Long> {
+    Optional<CompanyEmailVerification> findByEmail(String email);
+}

--- a/backend/src/main/java/com/beyond/specguard/verification/model/service/EmailVerificationService.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/service/EmailVerificationService.java
@@ -1,17 +1,27 @@
 package com.beyond.specguard.verification.model.service;
 
+import com.beyond.specguard.verification.model.entity.ApplicantEmailVerification;
+import com.beyond.specguard.verification.model.entity.CompanyEmailVerification;
+import com.beyond.specguard.verification.model.entity.EmailVerifyStatus;
+import com.beyond.specguard.verification.model.repository.ApplicantEmailVerificationRepo;
+import com.beyond.specguard.verification.model.repository.CompanyEmailVerificationRepo;
+import com.beyond.specguard.verification.model.type.VerifyTarget;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import com.beyond.specguard.verification.model.service.VerifySendGridService;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Slf4j
+@Getter
+@Setter
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationService {
@@ -19,27 +29,88 @@ public class EmailVerificationService {
     private final StringRedisTemplate redis;
     private final VerifySendGridService mailer;
 
+    private final ApplicantEmailVerificationRepo applicantRepo;
+    private final CompanyEmailVerificationRepo companyRepo;
+
     @Value("${verify.ttl-seconds:300}")
     private long ttlSeconds;
 
+    private static String norm(String e){ return e == null ? null : e.trim().toLowerCase(); }
     private String key(String email) { return "verif:email:" + email.toLowerCase(); }
     private String attemptKey(String email) { return "verif:attempt:" + email.toLowerCase(); }
 
-    public void requestCode(String email) throws IOException {
-        String code = RandomStringUtils.randomNumeric(6);
-        var k = key(email);
+    @Transactional
+    public void requestCode(String rawEmail, VerifyTarget target, String ip) {
+        final String email = norm(rawEmail);
+        final String code  = RandomStringUtils.randomNumeric(6);
+        final String k = key(email);
         redis.opsForValue().set(k, code, Duration.ofSeconds(ttlSeconds));
-        log.info("verify.set key={} code={} ttl={}", k, code, ttlSeconds);
-        mailer.sendCodeEmail(email, code, ttlSeconds);
+        log.info("verify.set key={} code(last2)=**{} ttl={}", k, code.substring(4), ttlSeconds);
+
+        upsertPending(rawEmail, target, ip);
+        mailer.sendCodeEmail(email, code, ttlSeconds); // unchecked 예외 전파
+
+
     }
 
-    public boolean verify(String email, String input) {
-        String saved = redis.opsForValue().get(key(email));
+    @Transactional
+    public boolean verify(String rawEmail, String input, VerifyTarget target) {
+        final String email = norm(rawEmail);
+        final String k = key(email);
+        String saved = redis.opsForValue().get(k);
         if (saved == null) return false;
+
         boolean ok = saved.equals(input);
-        if (ok) redis.delete(key(email));
-        else redis.opsForValue().increment(attemptKey(email)); // 선택: 실패 카운트
+        if (ok) {
+            markVerified(email, target);
+            redis.delete(key(email));
+        } else {
+            String ak = attemptKey(email);
+            Long n = redis.opsForValue().increment(ak);
+            if (n != null && n == 1L) redis.expire(ak, Duration.ofHours(1));
+        }
         return ok;
     }
+
+    private void upsertPending(String email, VerifyTarget t, String ip) {
+        if (t == VerifyTarget.APPLICANT) {
+            var e = applicantRepo.findByEmail(email).orElseGet(() -> {
+                var x = new ApplicantEmailVerification();
+                x.setEmail(email);
+                return x;
+            });
+            e.setStatus(EmailVerifyStatus.PENDING);
+            e.setAttempts(e.getAttempts() == null ? 1 : e.getAttempts() + 1);
+            e.setLastRequestedAt(LocalDateTime.now());
+            e.setLastIp(ip);
+            applicantRepo.save(e);
+        } else {
+            var e = companyRepo.findByEmail(email).orElseGet(() -> {
+                var x = new CompanyEmailVerification();
+                x.setEmail(email);
+                return x;
+            });
+            e.setStatus(EmailVerifyStatus.PENDING);
+            e.setAttempts(e.getAttempts() == null ? 1 : e.getAttempts() + 1);
+            e.setLastRequestedAt(LocalDateTime.now());
+            e.setLastIp(ip);
+            companyRepo.save(e);
+        }
+    }
+
+    private void markVerified(String email, VerifyTarget t) {
+        if (t == VerifyTarget.APPLICANT) {
+            var e = applicantRepo.findByEmail(email).orElseThrow();
+            e.setStatus(EmailVerifyStatus.VERIFIED);
+            e.setVerifiedAt(LocalDateTime.now());
+            applicantRepo.save(e);
+        } else {
+            var e = companyRepo.findByEmail(email).orElseThrow();
+            e.setStatus(EmailVerifyStatus.VERIFIED);
+            e.setVerifiedAt(LocalDateTime.now());
+            companyRepo.save(e);
+        }
+    }
 }
+
 

--- a/backend/src/main/java/com/beyond/specguard/verification/model/service/VerifySendGridService.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/service/VerifySendGridService.java
@@ -25,31 +25,31 @@ public class VerifySendGridService {
     @Value("${verify.mail.from-name:${sendgrid.mail.from-name}}")
     private String fromName;
 
-    public void sendCodeEmail(String toEmail, String code, long ttlSeconds) throws IOException {
-        Email from = new Email(fromEmail, fromName);
-        Email to = new Email(toEmail);
-        String subject = "[SpecGuard] 이메일 인증코드";
-        String body = """
-        <h3>이메일 인증코드</h3>
-        <p>아래 코드를 입력하세요. 유효시간 %d초</p>
-        <div style="font-size:24px;font-weight:700">%s</div>
-        """.formatted(ttlSeconds, code);
-
-        Content content = new Content("text/html", body);
-        Mail mail = new Mail(from, subject, to, content);
-
-        SendGrid sg = new SendGrid(apiKey);
-        Request req = new Request();
+    public void sendCodeEmail(String toEmail, String code, long ttlSeconds) {
         try {
+            Email from = new Email(fromEmail, fromName);
+            Email to = new Email(toEmail);
+            String subject = "[SpecGuard] 이메일 인증코드";
+            String body = """
+            <h3>이메일 인증코드</h3>
+            <p>아래 코드를 입력하세요. 유효시간 %d초</p>
+            <div style="font-size:24px;font-weight:700">%s</div>
+            """.formatted(ttlSeconds, code);
+
+            Content content = new Content("text/html", body);
+            Mail mail = new Mail(from, subject, to, content);
+
+            SendGrid sg = new SendGrid(apiKey);
+            Request req = new Request();
             req.setMethod(Method.POST);
             req.setEndpoint("mail/send");
             req.setBody(mail.build());
-            sg.api(req);
-        } catch (IOException e) {
-            throw new RuntimeException("Verification 메일 발송 실패", e);
+
+            Response res = sg.api(req);
+            log.info("SendGrid status={}, body={}", res.getStatusCode(), res.getBody());
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
         }
-        Response res = sg.api(req);
-        log.info("SendGrid status={}, body={}", res.getStatusCode(), res.getBody());
     }
 
 }

--- a/backend/src/main/java/com/beyond/specguard/verification/model/type/VerifyTarget.java
+++ b/backend/src/main/java/com/beyond/specguard/verification/model/type/VerifyTarget.java
@@ -1,0 +1,3 @@
+package com.beyond.specguard.verification.model.type;
+
+public enum VerifyTarget { APPLICANT, COMPANY }


### PR DESCRIPTION

[Feat] 이메일본인인증 상태 테이블 추가 (#93)


## 💡 작업 개요

- 본인인증 상태 저장 테이블 추가 (company applicant 분리)


</br>

## 🔨 작업 내용
- controller 단 인증 상태 파트 추가
- 상태관리 applicant / company 별도관리
- 본인인증 confim api request 수정


</br>


## 🎯 관련 이슈
- #93 

</br>


## 📚 참고 자료 (선택)
- 
